### PR TITLE
feat: Implementación de Canonical JSON

### DIFF
--- a/app/keystore.py
+++ b/app/keystore.py
@@ -8,6 +8,7 @@ import hashlib
 from datetime import datetime, timezone
 from typing import Optional, Tuple
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from .utils import canonical_json_bytes 
 
 # Ruta por defecto donde se almacenará el keystore si no se indica otra.
 DEFAULT_KEYSTORE_PATH = Path("app/keystore.json")
@@ -73,22 +74,6 @@ def aesgcm_encrypt(key: bytes, plaintext: bytes, *, aad: Optional[bytes] = None)
     aes = AESGCM(key)
     ct_with_tag = aes.encrypt(nonce, plaintext, aad)
     return nonce, ct_with_tag[:-16], ct_with_tag[-16:]
-
-
-# Implementacion básica de canonical json 
-# TODO: definir canonical json basado en RFC 8785 
-def canonical_json_bytes(obj) -> bytes:
-    """
-    Serializa un objeto a un JSON canónico
-    :param obj: Objeto serializable a JSON.
-    :return: Representación JSON canónica en bytes UTF-8.
-    """
-    return json.dumps(
-        obj,
-        separators=(",", ":"),
-        sort_keys=True,
-        ensure_ascii=False,
-    ).encode("utf-8")
 
 
 def _keystore_checksum(doc: dict) -> str:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,14 @@
+import json
+
+# Implementacion básica de canonical json 
+def canonical_json_bytes(obj) -> bytes:
+    """
+    Serializa un objeto a un JSON canónico (RFC 8785 subset).
+    Ordena llaves, quita espacios y usa UTF-8.
+    """
+    return json.dumps(
+        obj,
+        separators=(",", ":"),
+        sort_keys=True,
+        ensure_ascii=False,
+    ).encode("utf-8")


### PR DESCRIPTION
- Se movió la lógica de canonización a utils.py para reutilizarla en Transacciones.
- Se configuró json.dumps para eliminar espacios y ordenar llaves.

**Nota importante:** Por favor, no usen float para los montos de las transacciones, usen int o str, para evitar errores de hash.