### PR TITLE
Realicé las modificación a la función cdm_wallet_sing para que la llave que guarde en from sea la derivada

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ import json
 import base64
 
 from .keystore import create, DEFAULT_KEYSTORE_PATH, load
-from .address import address_from_pubkey
+from .address import load_address_from_keystore, address_from_pubkey
 from .tx import Tx
 from .signer import sign as sign_tx
 from .verifier import verify_tx, commit_verification
@@ -63,7 +63,8 @@ def cmd_wallet_sign(args: argparse.Namespace) -> None:
     state = load(passphrase, path)
     sk = state["sk"]
 
-    from_addr = state["doc"]["pubkey_b64"]
+    pubkey_bytes = state["pubkey_bytes"] # Usado para derivar la dirección
+    from_addr = address_from_pubkey(pubkey_bytes)
 
     tx = Tx(
         from_addr=from_addr,


### PR DESCRIPTION
Hice algunas modificaciones porque en pruebas manuales me generaba un error al tratar de comparar las llaves en la firma, pero ya se resolvió, solo antes de cuardar la llave en "from_addr" era necesario primero derivarla con "pubkey_bytes = state["pubkey_bytes"]"
